### PR TITLE
add autonormal

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Queries
     * [jlesquembre/pathom-pedestal](https://github.com/jlesquembre/pathom-pedestal): A library to integrate pathom and pedestal.
   - [graphqlize/honeyeql](https://github.com/graphqlize/honeyeql): HoneyEQL transforms EQL into efficient SQL.
     https://github.com/graphqlize/graphqlize
-  - [lilactown/autonormal](https://github.com/lilactown/autonormal): Autonormal provides tools to normalize and execute EQL queries on Clojure data
+  - [lilactown/autonormal](https://github.com/lilactown/autonormal): a library for storing and querying graph data in a Clojure map using EQL.
 * [sixthnormal/pullql](https://github.com/sixthnormal/pullql): A GraphQL-like query language for DataScript, optimized for execution across many entities at once.
 * [walkable-server/walkable](https://github.com/walkable-server/walkable): A Clojure(script) SQL library for building APIs: Datomic® (GraphQL-ish) pull syntax, data driven configuration, dynamic filtering with relations in mind.
 * [walmartlabs/lacinia](https://github.com/walmartlabs/lacinia): This library is a full implementation of Facebook's GraphQL specification.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Queries
     * [jlesquembre/pathom-pedestal](https://github.com/jlesquembre/pathom-pedestal): A library to integrate pathom and pedestal.
   - [graphqlize/honeyeql](https://github.com/graphqlize/honeyeql): HoneyEQL transforms EQL into efficient SQL.
     https://github.com/graphqlize/graphqlize
+  - [lilactown/autonormal](https://github.com/lilactown/autonormal): Autonormal provides tools to normalize and execute EQL queries on Clojure data
 * [sixthnormal/pullql](https://github.com/sixthnormal/pullql): A GraphQL-like query language for DataScript, optimized for execution across many entities at once.
 * [walkable-server/walkable](https://github.com/walkable-server/walkable): A Clojure(script) SQL library for building APIs: Datomic® (GraphQL-ish) pull syntax, data driven configuration, dynamic filtering with relations in mind.
 * [walmartlabs/lacinia](https://github.com/walmartlabs/lacinia): This library is a full implementation of Facebook's GraphQL specification.


### PR DESCRIPTION
Add [autonormal](https://github.com/lilactown/autonormal), a library for storing and querying graph data in a Clojure map using EQL.